### PR TITLE
Add infrastructure configuration and fix nginx reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tags*
 tags/
 .coverage
 coverage.xml
-infra/
+infrastructure/.terraform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 services:
-  mutants:
+  mutants_api:
     build:
       context: ./
       dockerfile: Dockerfile-dev

--- a/infrastructure/container_definitions.json
+++ b/infrastructure/container_definitions.json
@@ -1,0 +1,24 @@
+[
+    {
+        "name": "nginx",
+        "image": "642559655451.dkr.ecr.sa-east-1.amazonaws.com/nginx:c1e21b6",
+        "memory": 256,
+        "essential": true,
+        "portMappings": [
+            { 
+                "hostPort": 1337,
+                "containerPort": 80,
+                "protocol": "tcp"
+            }
+        ],
+        "links": [
+            "mutants_api"
+        ]
+    },
+    {
+        "name": "mutants_api",
+        "image": "642559655451.dkr.ecr.sa-east-1.amazonaws.com/mutants_api:c1e21b6",
+        "memory": 256,
+        "essential": true
+    }
+]

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,87 @@
+provider "aws" {
+  profile = "default"
+  region  = "sa-east-1"
+}
+
+# ------ ECS Cluster ------- #
+resource "aws_ecs_cluster" "mutants_ecs_cluster" {
+  name = "mutants_ecs_production"
+}
+
+
+# ------ EC2 Instances ------ #
+resource "aws_instance" "ec2_instance" {
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+  ami                  = "ami-03e1e4abf50e14ded"
+  instance_type        = "t2.micro"
+  user_data            = "${data.template_file.user_data.rendered}"
+  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
+  key_name             = "mutants-prod"
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/user_data.tpl")}"
+}
+
+
+output "ec2_instance_public_dns" {
+  value = "${aws_instance.ec2_instance.public_dns}"
+}
+
+
+# ------- IAM Roles, Policies and Profile ------- #
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "ecs_instance_role"
+  path               = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs_instance_policy.json}"
+}
+
+data "aws_iam_policy_document" "ecs_instance_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role_attachment" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_profile" {
+  name = "ecs_instance_profile"
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+
+# ------ ECS Service and Task Definitions ------ #
+resource "aws_ecs_service" "mutants_service" {
+  name            = "mutants"
+  cluster         = aws_ecs_cluster.mutants_ecs_cluster.id
+  launch_type     = "EC2"
+  task_definition = aws_ecs_task_definition.mutants_api.arn
+  desired_count   = 1
+}
+
+resource "aws_ecs_task_definition" "mutants_api" {
+  family                = "mutants_stack"
+  container_definitions = file("container_definitions.json")
+  network_mode          = "bridge"
+}
+
+
+# ------ ECR ------- #
+resource "aws_ecr_repository" "ecr_mutants_api" {
+  name = "mutants_api"
+}
+
+resource "aws_ecr_repository" "ecr_nginx" {
+  name = "nginx"
+}
+
+output "ecr_mutants_repository_url" {
+  value = "${aws_ecr_repository.ecr_mutants_api.repository_url}"
+}

--- a/infrastructure/user_data.tpl
+++ b/infrastructure/user_data.tpl
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Update all packages
+# We need to install and initialize the ECS agent manually
+# because we can't afford an ECS-optimized image :D
+
+sudo yum update -y
+sudo yum install -y ecs-init
+sudo service docker start
+sudo start ecs
+
+echo ECS_CLUSTER=mutants_ecs_production >> /etc/ecs/ecs.config
+cat /etc/ecs/ecs.config | grep "ECS_CLUSTER"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
-upstream mutants {
-    server mutants:5000;
+upstream mutants_api {
+    server mutants_api:5000;
 }
 
 server {
@@ -11,7 +11,7 @@ server {
     error_log  /var/log/nginx/error.log;
 
     location / {
-        proxy_pass         http://mutants;
+        proxy_pass         http://mutants_api;
         proxy_redirect     off;
 
         proxy_set_header   Host                 $host;


### PR DESCRIPTION
Vamos a usar terraform para poder cambiar la infraestructura de una manera simple y más fácil de manejar, además de poder registrarla en un VCS y todos los beneficios que da la [infraestructura como código](https://en.wikipedia.org/wiki/Infrastructure_as_code). Además podemos eliminar toda la infra que creamos y volverla a crear de manera rápida, lo que nos hace ahorrar plata mientras no la estoy usando :)