### PR TITLE
Add LB into the mix. Use ECS-optimized images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tags/
 coverage.xml
 infrastructure/.terraform
 infrastructure/terraform.tfstate*
+infrastructure/capacity.txt
 docker-compose.prod*
 mongosetup
 mongo/*conf

--- a/infrastructure/alb.tf
+++ b/infrastructure/alb.tf
@@ -1,0 +1,36 @@
+resource "aws_alb" "mutants_alb" {
+  name            = "mutants-alb"
+  subnets         = [aws_subnet.mutants_vpc_subnet_a.id, aws_subnet.mutants_vpc_subnet_b.id]
+  security_groups = [aws_security_group.mutants_vpc_security_group.id]
+  internal        = false
+}
+
+resource "aws_alb_listener" "mutants_alb_listener" {
+  load_balancer_arn = aws_alb.mutants_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+  
+  default_action {
+    target_group_arn = aws_alb_target_group.mutants_alb_target_group.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_target_group" "mutants_alb_target_group" {
+  name     = "mutants-alb-target-group"
+  port     = "80"
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.mutants_vpc.id
+
+  health_check {
+    healthy_threshold   = 3
+    unhealthy_threshold = 10
+    timeout             = 5
+    interval            = 10
+    path                = "/api/stats/"
+  }
+}
+
+output "mutants_alb_dns_name" {
+  value = "${aws_alb.mutants_alb.dns_name}"
+}

--- a/infrastructure/container_definitions.json
+++ b/infrastructure/container_definitions.json
@@ -6,7 +6,6 @@
     "essential": true,
     "portMappings": [
       { 
-        "hostPort": 1337,
         "containerPort": 80,
         "protocol": "tcp"
       }
@@ -17,7 +16,7 @@
   },
   {
     "name": "mutants_api",
-    "image": "642559655451.dkr.ecr.sa-east-1.amazonaws.com/mutants_api:b378c0c",
+    "image": "642559655451.dkr.ecr.sa-east-1.amazonaws.com/mutants_api:ceaba91",
     "memory": 256,
     "essential": true,
     "executionRoleArn": "arn:aws:iam::642559655451:role/ecsTaskExecutionRole",

--- a/infrastructure/ec2.tf
+++ b/infrastructure/ec2.tf
@@ -1,17 +1,19 @@
 # ------ EC2 Instances ------ #
 resource "aws_instance" "ec2_instance" {
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-  ami                  = "ami-03e1e4abf50e14ded"
-  instance_type        = "t2.micro"
-  user_data            = "${data.template_file.user_data.rendered}"
-  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
-  key_name             = "mutants-prod"
+  ami                    = "ami-0d6ac368fff49ff2d"
+  instance_type          = "t2.medium"
+  user_data              = "${data.template_file.user_data.rendered}"
+  iam_instance_profile   = aws_iam_instance_profile.ecs_instance_profile.name
+  key_name               = "mutants-prod"
+
+  vpc_security_group_ids = [aws_security_group.mutants_vpc_security_group.id]
+  subnet_id              = aws_subnet.mutants_vpc_subnet_a.id
 }
 
 data "template_file" "user_data" {
   template = "${file("${path.module}/user_data.tpl")}"
 }
-
 
 output "ec2_instance_public_dns" {
   value = "${aws_instance.ec2_instance.public_dns}"

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -10,7 +10,14 @@ resource "aws_ecs_service" "mutants_service" {
   cluster         = aws_ecs_cluster.mutants_ecs_cluster.id
   launch_type     = "EC2"
   task_definition = aws_ecs_task_definition.mutants_api.arn
-  desired_count   = 1
+  desired_count   = 3
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.mutants_alb_target_group.arn
+    container_name   = "nginx"
+    container_port   = 80
+  }
+
 }
 
 resource "aws_ecs_task_definition" "mutants_api" {

--- a/infrastructure/sg.tf
+++ b/infrastructure/sg.tf
@@ -1,0 +1,22 @@
+# Create the Security Group
+resource "aws_security_group" "mutants_vpc_security_group" {
+  description  = "Security Group for mutants_vpc"
+  name         = "mutants_vpc_security_group"
+  vpc_id       = aws_vpc.mutants_vpc.id
+  
+  # allow ingress of all ports for now
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  } 
+  
+  # allow egress of all ports
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+}

--- a/infrastructure/user_data.tpl
+++ b/infrastructure/user_data.tpl
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# Update all packages
-# We need to install and initialize the ECS agent manually
-# because we can't afford an ECS-optimized image :D
-
-sudo yum update -y
-sudo yum install -y ecs-init
-sudo service docker start
-sudo start ecs
-
 echo ECS_CLUSTER=mutants_ecs_production >> /etc/ecs/ecs.config
 echo ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true >> /etc/ecs/ecs.config
 cat /etc/ecs/ecs.config | grep "ECS_CLUSTER"

--- a/infrastructure/vpc.tf
+++ b/infrastructure/vpc.tf
@@ -1,0 +1,47 @@
+resource "aws_vpc" "mutants_vpc" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "mutants_vpc_subnet_a" {
+  vpc_id                  = aws_vpc.mutants_vpc.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "sa-east-1a"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "mutants_vpc_subnet_b" {
+  vpc_id                  = aws_vpc.mutants_vpc.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "sa-east-1b"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "mutants_vpc_internet_gateway" {
+  vpc_id = aws_vpc.mutants_vpc.id
+}
+
+resource "aws_route_table" "mutants_vpc_route_table" {
+  vpc_id = aws_vpc.mutants_vpc.id
+}
+
+resource "aws_route" "mutants_vpc_internet_access_route" {
+  route_table_id         = aws_route_table.mutants_vpc_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.mutants_vpc_internet_gateway.id
+}
+
+resource "aws_main_route_table_association" "a" {
+  vpc_id         = aws_vpc.mutants_vpc.id
+  route_table_id = aws_route_table.mutants_vpc_route_table.id
+}
+
+resource "aws_route_table_association" "mutants_vpc_subnet_a_association" {
+  subnet_id      = aws_subnet.mutants_vpc_subnet_a.id
+  route_table_id = aws_route_table.mutants_vpc_route_table.id
+}
+
+resource "aws_route_table_association" "mutants_vpc_subnet_b_association" {
+  subnet_id      = aws_subnet.mutants_vpc_subnet_b.id
+  route_table_id = aws_route_table.mutants_vpc_route_table.id
+}

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -8,17 +8,21 @@ DNA_NUCLEOBASES = ["A", "C", "G", "T"]
 
 class UserBehavior(TaskSet):
 
-    @task
+    @task(2)
     def is_mutant(self):
         dna_matrix = generate_matrix(random.randint(4, 10))
         with self.client.post("/api/mutant/", json={"dna": dna_matrix}, catch_response=True) as response:
             if response.status_code == 403:
                 response.success()
 
+    @task(1)
+    def get_stats(self):
+        self.client.get("/api/stats/")
+
 
 class WebsiteUser(HttpLocust):
     task_set = UserBehavior
-    wait_time = between(1, 3)
+    wait_time = between(5, 10)
 
 
 def generate_matrix(size):


### PR DESCRIPTION
Agregamos un balanceador de carga a la mezcla para que podamos correr múltiples instancias iguales y repartir el tráfico uniformemente entre ellas. En este caso en particular el Balanceador de Carga de AWS –ALB por Application Load Balancer en inglés– usa el algoritmo [Round Robin](https://en.wikipedia.org/wiki/Round-robin_scheduling). También creamos nuestra propia VPC en vez de usar la que viene por default en AWS. Luego vamos a configurarla un poco para que el tráfico que llega a nuestros servidores sea más controlado.