### PR TITLE
Add autoscaling functionality to our EC2 cluster based on CloudWatch metrics

### DIFF
--- a/infrastructure/alb.tf
+++ b/infrastructure/alb.tf
@@ -1,6 +1,9 @@
 resource "aws_alb" "mutants_alb" {
   name            = "mutants-alb"
-  subnets         = [aws_subnet.mutants_vpc_subnet_a.id, aws_subnet.mutants_vpc_subnet_b.id]
+  subnets         = [
+    aws_subnet.mutants_vpc_subnet_a.id,
+    aws_subnet.mutants_vpc_subnet_c.id
+  ]
   security_groups = [aws_security_group.mutants_vpc_security_group.id]
   internal        = false
 }

--- a/infrastructure/cw.tf
+++ b/infrastructure/cw.tf
@@ -1,0 +1,39 @@
+resource "aws_cloudwatch_metric_alarm" "ecs_cluster_memory_reservation_upper_threshold_metric_alarm" {
+  alarm_name          = "ecs_cluster_memory_reservation_upper_threshold_metric_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Maximum"
+  threshold           = "80"
+
+  dimensions = {
+    ClusterName          = aws_ecs_cluster.mutants_ecs_cluster.name
+  }
+
+  alarm_description = "Triggers when ECS Cluster MemoryReservation is at 80% or higher."
+  alarm_actions     = [
+    aws_autoscaling_policy.mutants_ecs_cluster_autoscaling_up_policy.arn
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cluster_memory_reservation_lower_metric_alarm" {
+  alarm_name          = "ecs_cluster_memory_reservation_lower_metric_alarm"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Maximum"
+  threshold           = "40"
+
+  dimensions          = {
+    ClusterName       = aws_ecs_cluster.mutants_ecs_cluster.name
+  }
+
+  alarm_description   = "Triggers when ECS Cluster MemoryReservation is at 40% or lower."
+  alarm_actions       = [
+    aws_autoscaling_policy.mutants_ecs_cluster_autoscaling_down_policy.arn
+  ]
+}

--- a/infrastructure/ec2.tf
+++ b/infrastructure/ec2.tf
@@ -1,20 +1,58 @@
 # ------ EC2 Instances ------ #
-resource "aws_instance" "ec2_instance" {
-  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-  ami                    = "ami-0d6ac368fff49ff2d"
-  instance_type          = "t2.medium"
-  user_data              = "${data.template_file.user_data.rendered}"
-  iam_instance_profile   = aws_iam_instance_profile.ecs_instance_profile.name
-  key_name               = "mutants-prod"
-
-  vpc_security_group_ids = [aws_security_group.mutants_vpc_security_group.id]
-  subnet_id              = aws_subnet.mutants_vpc_subnet_a.id
-}
 
 data "template_file" "user_data" {
   template = "${file("${path.module}/user_data.tpl")}"
 }
 
-output "ec2_instance_public_dns" {
-  value = "${aws_instance.ec2_instance.public_dns}"
+resource "aws_launch_configuration" "mutants_ecs_cluster_launch_configuration" {
+  name                        = "mutants_ecs_cluster_launch_configuration"
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+  image_id                    = "ami-0d6ac368fff49ff2d"
+  instance_type               = "t2.medium"
+  user_data                   = "${data.template_file.user_data.rendered}"
+  iam_instance_profile        = aws_iam_instance_profile.ecs_instance_profile.name
+  key_name                    = "mutants-prod"
+
+  security_groups             = [aws_security_group.mutants_vpc_security_group.id]
+
+  root_block_device {
+    volume_type = "standard"
+    volume_size = 100
+    delete_on_termination = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "mutants_ecs_cluster_autoscaling_group" {
+  name                        = "mutants_ecs_cluster_autoscaling_group"
+  max_size                    = 2
+  min_size                    = 1
+  vpc_zone_identifier         = [
+    aws_subnet.mutants_vpc_subnet_a.id,
+    aws_subnet.mutants_vpc_subnet_c.id
+  ]
+  target_group_arns           = [
+    aws_alb_target_group.mutants_alb_target_group.arn
+  ]
+  launch_configuration        = aws_launch_configuration.mutants_ecs_cluster_launch_configuration.name
+  health_check_type           = "EC2"
+}
+
+resource "aws_autoscaling_policy" "mutants_ecs_cluster_autoscaling_up_policy" {
+  name                   = "mutants_ecs_cluster_autoscaling_up_policy"
+  scaling_adjustment     = 1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = aws_autoscaling_group.mutants_ecs_cluster_autoscaling_group.name
+}
+
+resource "aws_autoscaling_policy" "mutants_ecs_cluster_autoscaling_down_policy" {
+  name                   = "mutants_ecs_cluster_autoscaling_down_policy"
+  scaling_adjustment     = -1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = aws_autoscaling_group.mutants_ecs_cluster_autoscaling_group.name
 }

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -10,13 +10,17 @@ resource "aws_ecs_service" "mutants_service" {
   cluster         = aws_ecs_cluster.mutants_ecs_cluster.id
   launch_type     = "EC2"
   task_definition = aws_ecs_task_definition.mutants_api.arn
-  desired_count   = 3
+  desired_count   = 4
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.mutants_alb_target_group.arn
     container_name   = "nginx"
     container_port   = 80
+    target_group_arn = aws_alb_target_group.mutants_alb_target_group.arn
   }
+
+  depends_on = [
+    aws_alb.mutants_alb
+  ]
 
 }
 

--- a/infrastructure/vpc.tf
+++ b/infrastructure/vpc.tf
@@ -10,10 +10,10 @@ resource "aws_subnet" "mutants_vpc_subnet_a" {
   map_public_ip_on_launch = true
 }
 
-resource "aws_subnet" "mutants_vpc_subnet_b" {
+resource "aws_subnet" "mutants_vpc_subnet_c" {
   vpc_id                  = aws_vpc.mutants_vpc.id
   cidr_block              = "10.0.2.0/24"
-  availability_zone       = "sa-east-1b"
+  availability_zone       = "sa-east-1c"
   map_public_ip_on_launch = true
 }
 
@@ -41,7 +41,7 @@ resource "aws_route_table_association" "mutants_vpc_subnet_a_association" {
   route_table_id = aws_route_table.mutants_vpc_route_table.id
 }
 
-resource "aws_route_table_association" "mutants_vpc_subnet_b_association" {
-  subnet_id      = aws_subnet.mutants_vpc_subnet_b.id
+resource "aws_route_table_association" "mutants_vpc_subnet_c_association" {
+  subnet_id      = aws_subnet.mutants_vpc_subnet_c.id
   route_table_id = aws_route_table.mutants_vpc_route_table.id
 }


### PR DESCRIPTION
Vamos a auto-escalar el cluster de EC2 basandonos en métricas de CloudWatch:

Si el cluster de ECS tiene 80% o más de la memoria reservada por containers, agregamos una instancia de EC2.

Si el cluster de ECS tien 40% o menos de la memoria reservada por containers, damos de baja una instancia.