### PR TITLE
Provide a healthcheck endpoint

### DIFF
--- a/flaskr/api/views.py
+++ b/flaskr/api/views.py
@@ -82,6 +82,11 @@ def stats() -> Response:
     )
 
 
+@bp.route("/healthcheck/", methods=["GET"])
+def healthcheck() -> Response:
+    return Response(None, status=200, mimetype="application/json")
+
+
 # No creemos que Magneto quiera las estadísticas de mutantes vs. humanos en tiempo real
 # aunque no nos lo ha aclarado! Por ahora, para evitar martillar la base de datos con
 # queries innecesarias durante cargas pesadas, vamos a cachear la respuesta durante 10 segundos.

--- a/infrastructure/alb.tf
+++ b/infrastructure/alb.tf
@@ -30,7 +30,7 @@ resource "aws_alb_target_group" "mutants_alb_target_group" {
     unhealthy_threshold = 10
     timeout             = 5
     interval            = 10
-    path                = "/api/stats/"
+    path                = "/api/healthcheck/"
   }
 }
 

--- a/tests/api/test_healthcheck.py
+++ b/tests/api/test_healthcheck.py
@@ -1,0 +1,6 @@
+def test_healthcheck_returns_200(client):
+
+    response = client.get("/api/healthcheck/")
+
+    assert 200 == response.status_code
+    assert not response.data


### PR DESCRIPTION
Creamos un endpoint extra llamado "healthcheck" que es al que va a llamar el balanceador de carga para saber si el server está vivo o no. Proveemos este endpoint en vez de usar /stats/ ya que este no hace ningún trabajo extra más que proveer información acerca del estado de salud del servidor.